### PR TITLE
added implementation validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
-function createInterface () {
+function createInterface() {
   // retrieved forced function names
   var functionNames = Array.prototype.slice.call(arguments)
 
-  function Interface () {
+  function Interface() {
     var constructor = this.constructor
 
     if (constructor === Interface) {
       // Interface is being created on it's own
       throw new Error('Cannot create an instance of Interface')
     } else {
-      // assert that each of the functions are defined on the prototype
-      var prototype = Object.getPrototypeOf(this)
-      var unimplemented = []
+      var prototype = Object.getPrototypeOf(this);
+      var unimplemented = [];
 
-      functionNames.forEach(function (functionName) {
+      functionNames.forEach(function(functionName) {
         if (typeof prototype[functionName] !== 'function') {
           unimplemented.push(functionName)
         }
@@ -27,8 +26,23 @@ function createInterface () {
     }
   }
 
+  // expose valiate function
+  Interface.isImplementedBy = function(object) {
+    var prototype = Object.getPrototypeOf(object);
+
+    var length = functionNames.length;
+    while (length--) {
+      if (typeof prototype[functionNames[length]] !== 'function') {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
   return Interface
 }
+
 
 createInterface.create = createInterface
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,13 +3,13 @@ var expect = require('chai').expect
 var Interface = require('../index.js')
 var inherits = require('util').inherits
 
-describe('interface', function () {
+describe('interface', function() {
   // eslint-disable-next-line no-unused-vars
   var instance
   var MyInterface
 
-  function applyTestSuite () {
-    it('should not allow an interface to be instantiated', function () {
+  function applyTestSuite() {
+    it('should not allow an interface to be instantiated', function() {
       try {
         instance = new MyInterface()
         throw new Error('Interface was instantiated')
@@ -18,8 +18,8 @@ describe('interface', function () {
       }
     })
 
-    it('should throw an error message showing all unimplemented methods', function () {
-      function MyClass () {
+    it('should throw an error message showing all unimplemented methods', function() {
+      function MyClass() {
         MyInterface.call(this)
       }
 
@@ -31,26 +31,26 @@ describe('interface', function () {
       }
     })
 
-    it('should not throw an error when instantiating a class enforcing all given interfaces', function () {
-      function MyClass () {
+    it('should not throw an error when instantiating a class enforcing all given interfaces', function() {
+      function MyClass() {
         MyInterface.call(this)
       }
 
-      MyClass.prototype.methodA = function () {}
-      MyClass.prototype.methodB = function () {}
-      MyClass.prototype.methodC = function () {}
+      MyClass.prototype.methodA = function() {}
+      MyClass.prototype.methodB = function() {}
+      MyClass.prototype.methodC = function() {}
 
       instance = new MyClass()
     })
 
-    it('should enforce an interface on subclasses', function () {
-      function MyClass () {
+    it('should enforce an interface on subclasses', function() {
+      function MyClass() {
         MyInterface.call(this)
       }
 
-      MyClass.prototype.methodA = function () {}
+      MyClass.prototype.methodA = function() {}
 
-      function MySubClass () {
+      function MySubClass() {
         MyClass.call(this)
       }
 
@@ -64,24 +64,24 @@ describe('interface', function () {
       }
     })
 
-    it('should not throw an error for subclasses that implement all functions in the interface', function () {
-      function MyClass () {
+    it('should not throw an error for subclasses that implement all functions in the interface', function() {
+      function MyClass() {
         MyInterface.call(this)
       }
       inherits(MyClass, MyInterface)
 
-      MyClass.prototype.methodA = function () {}
+      MyClass.prototype.methodA = function() {}
 
-      function MySubClass () {
+      function MySubClass() {
         MyClass.call(this)
       }
 
       inherits(MySubClass, MyClass)
-      MySubClass.prototype.methodB = function () {}
-      MySubClass.prototype.methodC = function () {}
+      MySubClass.prototype.methodB = function() {}
+      MySubClass.prototype.methodC = function() {}
 
 
-      function MySubSubClass () {
+      function MySubSubClass() {
         MyClass.call(this)
       }
 
@@ -90,27 +90,47 @@ describe('interface', function () {
     })
   }
 
-  context('using the supplied "create" method', function () {
-    before(function () {
+  context('using the supplied "create" method', function() {
+    before(function() {
       MyInterface = Interface.create('methodA', 'methodB', 'methodC')
     })
 
     applyTestSuite()
   })
 
-  context('calling the exposed function directly', function () {
-    before(function () {
+  context('calling the exposed function directly', function() {
+    before(function() {
       MyInterface = Interface('methodA', 'methodB', 'methodC')
     })
 
     applyTestSuite()
   })
 
-  context('creating a "new" interface', function () {
-    before(function () {
+  context('creating a "new" interface', function() {
+    before(function() {
       MyInterface = new Interface('methodA', 'methodB', 'methodC')
     })
 
     applyTestSuite()
   })
+
+  describe("validate implementation without being a child of interface", function() {
+    var MyInterface = new Interface("methodA");
+
+    it("should return false for bad child", function() {
+      class BadChild {}
+
+      expect(MyInterface.isImplementedBy(new BadChild)).to.be.false;
+    });
+
+    it("should return true for good child", function() {
+      class GoodChild extends MyInterface {
+        methodA() {
+          return true;
+        }
+      }
+
+      expect(MyInterface.isImplementedBy(new GoodChild)).to.be.true;
+    });
+  });
 })


### PR DESCRIPTION
This is a pretty neat library and I was using it but I needed a way to validate if an object implements an interface without extending from it, suppose following example

```
class Creature {
  live() { ... }
}

class Human extends Creature {
  walk() { ... }
}

class Bee extends Creature {
  fly() { ... }
}

class Bird extends Creature {
  fly() { ... }
}

class Pigeon extends Bird {
  eatBreadCrumbs() { ... }
}

class Vulture extends Bird {
  eatCarrion() { ... }
}
```

Now suppose I create an interface 

    var Flying = new Interface("fly");

Now I can't extend it from neither my `Bird` nor my `Bee` classes because they already extend the `Creature` class and I can't inherit the interface from the `Creature` class obviously because it can't fly.

So what I've done is I've added a way to validate whether an object implements an interface without having to extend it.

```
var myVulture = new Vulture();

Flying.isImplementedBy(myVulture); // true
```